### PR TITLE
Add Http2 support & envoy

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,3 +1,4 @@
 envoy/envoy-c4b7ab805f238206d8b806e12cedb9420e5d936a-1.16.3.tgz:
   size: 13886834
+  object_id: 29fb66ee-09cc-476a-42be-e00e921639cd
   sha: sha256:4fa744357dd9369610bb57d71415b0dfef048bd2a4ae3f5e7d583181ea1c7538

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,1 +1,3 @@
----
+envoy:
+  size: 13886834
+  sha: sha256:4fa744357dd9369610bb57d71415b0dfef048bd2a4ae3f5e7d583181ea1c7538

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,3 +1,3 @@
-envoy:
+envoy/envoy-c4b7ab805f238206d8b806e12cedb9420e5d936a-1.16.3.tgz:
   size: 13886834
   sha: sha256:4fa744357dd9369610bb57d71415b0dfef048bd2a4ae3f5e7d583181ea1c7538

--- a/jobs/envoy/monit
+++ b/jobs/envoy/monit
@@ -1,0 +1,5 @@
+check process envoy
+  with pidfile /var/vcap/sys/run/envoy/pid
+  start program "/var/vcap/jobs/envoy/bin/ctl start"
+  stop program "/var/vcap/jobs/envoy/bin/ctl stop"
+  group vcap

--- a/jobs/envoy/spec
+++ b/jobs/envoy/spec
@@ -1,0 +1,13 @@
+---
+name: envoy
+
+templates:
+  ctl.erb: bin/ctl
+  envoy.yaml.erb: config/envoy.yaml
+  sds-server-validation-context.yaml.erb: config/sds-server-validation-context.yaml
+  sds-server-cert-and-key.yaml.erb: config/sds-server-cert-and-key.yaml
+
+packages:
+  - envoy
+
+properties: {}

--- a/jobs/envoy/spec
+++ b/jobs/envoy/spec
@@ -4,8 +4,8 @@ name: envoy
 templates:
   ctl.erb: bin/ctl
   envoy.yaml.erb: config/envoy.yaml
-  sds-server-validation-context.yaml.erb: config/sds-server-validation-context.yaml
-  sds-server-cert-and-key.yaml.erb: config/sds-server-cert-and-key.yaml
+  sds-server-validation-context.yaml.erb: config/certs/sds-server-validation-context.yaml
+  sds-server-cert-and-key.yaml.erb: config/certs/sds-server-cert-and-key.yaml
 
 packages:
   - envoy

--- a/jobs/envoy/spec
+++ b/jobs/envoy/spec
@@ -10,4 +10,14 @@ templates:
 packages:
   - envoy
 
-properties: {}
+properties:
+  client_validation.ca_certificate:
+    description: "The CA that signed the client cert/key used by the perf test client."
+    default: ""
+  server_tls.certificate:
+    description: "The certificate for the TLS endpoint"
+    default: ""
+  server_tls.private_key:
+    description: "The private key for the TLS endpoint"
+    default: ""
+

--- a/jobs/envoy/templates/ctl.erb
+++ b/jobs/envoy/templates/ctl.erb
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+RUN_DIR=/var/vcap/sys/run/envoy
+LOG_DIR=/var/vcap/sys/log/envoy
+PIDFILE=${RUN_DIR}/pid
+
+export PORT=8080
+
+case $1 in
+
+  start)
+    mkdir -p $RUN_DIR $LOG_DIR
+    chown -R vcap:vcap $RUN_DIR $LOG_DIR
+
+    echo $$ > $PIDFILE
+
+    exec /var/vcap/packages/envoy/bin/envoy \
+      --config-path /var/vcap/jobs/envoy/config/envoy.yaml \
+      >>  $LOG_DIR/envoy.stdout.log \
+      2>> $LOG_DIR/envoy.stderr.log
+
+    ;;
+
+  stop)
+    kill -9 `cat $PIDFILE`
+    rm -f $PIDFILE
+
+    ;;
+
+  *)
+    echo "Usage: ctl {start|stop}" ;;
+
+esac

--- a/jobs/envoy/templates/envoy.yaml.erb
+++ b/jobs/envoy/templates/envoy.yaml.erb
@@ -27,7 +27,7 @@ static_resources:
   listeners:
   - address:
       socket_address:
-        address: 127.0.0.1
+        address: 0.0.0.0
         port_value: 61001
     filter_chains:
     - filters:

--- a/jobs/envoy/templates/envoy.yaml.erb
+++ b/jobs/envoy/templates/envoy.yaml.erb
@@ -1,0 +1,61 @@
+admin:
+  access_log_path: /var/vcap/sys/log/envoy/envoy.log
+  address:
+    socket_address:
+      address: 127.0.0.1
+      port_value: 61003
+node:
+  cluster: proxy-cluster
+  id: envoy-cluster
+static_resources:
+  clusters:
+  - circuit_breakers:
+      thresholds:
+      - max_connections: 4294967295
+    connect_timeout: 0.250s
+    load_assignment:
+      cluster_name: 0-service-cluster
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 8080
+    name: 0-service-cluster
+    type: STATIC
+  listeners:
+  - address:
+      socket_address:
+        address: 127.0.0.1
+        port_value: 61001
+    filter_chains:
+    - filters:
+      - name: envoy.tcp_proxy
+        typed_config:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: 0-service-cluster
+          stat_prefix: 0-stats
+      transport_socket:
+        name: listener-8080
+        typed_config:
+          '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+          common_tls_context:
+            alpn_protocols: [ "h2,http/1.1" ]
+            tls_certificate_sds_secret_configs:
+            - name: server-cert-and-key
+              sds_config:
+                path: /var/vcap/jobs/envoy/config/certs/sds-server-cert-and-key.yaml
+            tls_params:
+              cipher_suites:
+              - ECDHE-RSA-AES256-GCM-SHA384
+              - ECDHE-RSA-AES128-GCM-SHA256
+            validation_context_sds_secret_config:
+              name: server-validation-context
+              sds_config:
+                path: /var/vcap/jobs/envoy/config/certs/sds-server-validation-context.yaml
+          require_client_certificate: true
+    name: listener-8080
+stats_config:
+  stats_matcher:
+    reject_all: true

--- a/jobs/envoy/templates/sds-server-cert-and-key.yaml.erb
+++ b/jobs/envoy/templates/sds-server-cert-and-key.yaml.erb
@@ -1,0 +1,79 @@
+resources:
+- '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
+  name: server-cert-and-key
+  tls_certificate:
+    certificate_chain:
+      inline_string: |
+        -----BEGIN CERTIFICATE-----
+        MIID8zCCAtugAwIBAgIRAMw1kJA6YUArVF0UsjUgobEwDQYJKoZIhvcNAQELBQAw
+        HTEbMBkGA1UEAxMSaW5zdGFuY2VJZGVudGl0eUNBMB4XDTIxMDMwMjE5MjUxM1oX
+        DTIxMDMwMzE5MjUxM1owgcgxgZ4wLwYDVQQLEyhhcHA6ZGRlN2YxZmItNDg1ZC00
+        NjNmLTg3ZDUtNWQ5MGIxZTNmMDUwMDEGA1UECxMqc3BhY2U6ZmY4NzAzNGQtZGRk
+        Yi00YjlmLThmNWYtODhiZmQxZTM1ZGRkMDgGA1UECxMxb3JnYW5pemF0aW9uOmMy
+        YWM3ZWQxLTQzZTItNGI2MC1iOWYxLTUyYWNlMWU4NGU1ZDElMCMGA1UEAxMcZWY1
+        NGExNDgtNGY0OC00NWI5LTdmZDEtODQzNjCCASIwDQYJKoZIhvcNAQEBBQADggEP
+        ADCCAQoCggEBANLKN4T2UffAi3Jj1F79jIgO+GY40eoDzD3jxXPFwnuCRt5L6vWz
+        1JpB8UIlBacsdw2WPOGPH5WUdl2hPG6iaM6qeo4nApErWTYt4wLBxfApCBJgbN0z
+        95oDOrbLLKc1YoXjdjyssgFsTcoZW8UFleB4ZzEDExbFMxOIG7CFd6QGn0H0GVwp
+        hamdq1PqFSVrWD+2C3pwaI4KdUONVjMRTg83Va50IeLlYrC91h5BDL6J3eJCQKw4
+        1G7lOGA012UpNPeyFHk2mefVEhMg0/Z8q0/q3rKxqvKY3KxfF5xB0FpWi1XorFl+
+        0Jcg/AMUNZ8a9S51z7Jcror6Ous5HPc4qf0CAwEAAaOBgTB/MA4GA1UdDwEB/wQE
+        AwIDqDAdBgNVHSUEFjAUBggrBgEFBQcDAgYIKwYBBQUHAwEwHwYDVR0jBBgwFoAU
+        obDjWbp4kN6+EiGqO5L5wX1NXN0wLQYDVR0RBCYwJIIcZWY1NGExNDgtNGY0OC00
+        NWI5LTdmZDEtODQzNocECv/yODANBgkqhkiG9w0BAQsFAAOCAQEAo+QbfyWu+Cuj
+        HzyqT5SgFcfp7YmRkI80vFR+KKNzU6HmbEIfcllfnOU5nyLCz99hMWP+NqyOy7NB
+        o840RdyyvoctFWgNMo5YtM34hNmnxA2Y5Hmgty6nmcOVKVmcKVjVXRVQxPgUKIBp
+        6lbzBh6fFe+NzbzYbfRLJdoOs6EAlTrUgFxSolOCArl1Lxq9UoV0mm9q9MdeQUut
+        zrlcvxfV37ygmSxU8bsIlbFRz5rQ6bkm9mECtvO4BfJ9h3hD9Hqv1/788Bc6Knag
+        vmcZKrff2bbv47tJngGgb9iNY3MAQUSZVfo6t013RLBSQJEF65UMk3TAZEoFTy4q
+        2w9l90cbRQ==
+        -----END CERTIFICATE-----
+        -----BEGIN CERTIFICATE-----
+        MIIDEjCCAfqgAwIBAgIUEUIA+osyBcSIDvc0w5TMCRfzNokwDQYJKoZIhvcNAQEL
+        BQAwFDESMBAGA1UEAxMJYXBwUm9vdENBMB4XDTIxMDMwMjExNDMyOFoXDTIyMDMw
+        MjExNDMyOFowHTEbMBkGA1UEAxMSaW5zdGFuY2VJZGVudGl0eUNBMIIBIjANBgkq
+        hkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuGnM+CcZEyH8r/K0pFKt2CRVY20x9php
+        Xg50dvBUCLp3tCXrGR13gfkL5krHFK2IJqe1E3Q9n0xo+yiHny35UkE911/plC9h
+        0GfuWAgEic4SdvB6cA/Lbx1ekRBR8ZkSZfu0Fl1AE9oHdJmfzZrkqEpSizcE3DZE
+        TmsjO/NuMVjwrFVddkMMDr0bsD8xVm2C0bEVMSuLvgG0NMkQn9NsBBxc5HvKQo2S
+        gVQFLLgEvc5eYxmeRG8/Ncsy/3fzdhs+lUquFaAIxwITBTbyg2HtYgtdMzy08BWf
+        3i8IpyZ/e5DFOWJkcXj+bG/WU2TVipzOoEMBY8R9IvUjuLwFMZb1fwIDAQABo1Mw
+        UTAdBgNVHQ4EFgQUobDjWbp4kN6+EiGqO5L5wX1NXN0wHwYDVR0jBBgwFoAUpR+U
+        KIaorXZavygFU3LNEchuY8owDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsF
+        AAOCAQEAgqmuKS9HNS9p/b/k+8akVFWl2+cC6o/Yat0+uVncgrPgp2T6D1iAIQlH
+        xQSfDbCR8ksLGP/HhHsX/amfqxiBFlbzZbdH9FPZuIsMcW5K/t0LxR9fiwsP7HDK
+        pI6wHne/60hLKDYrWE8GppckhujfxcVdDY63qYcErONkWcaa11tMKVFrD0UKuLkb
+        ATOiE3IBZ3VbgvVUopTTbLlkaSzJOi/OzJB0JKWnCmrEuQxUgQ2jI28brYezGz7h
+        MhWJbFQCweE5v9zWHbHgHixOu5P0IK3d0BEZcbg8BnOIqoVN21n0hst5jeNv0z9K
+        dFmH+iNb0bUWmLXYK2jeZG5+yTvzYQ==
+        -----END CERTIFICATE-----
+    private_key:
+      inline_string: |
+        -----BEGIN RSA PRIVATE KEY-----
+        MIIEpAIBAAKCAQEA0so3hPZR98CLcmPUXv2MiA74ZjjR6gPMPePFc8XCe4JG3kvq
+        9bPUmkHxQiUFpyx3DZY84Y8flZR2XaE8bqJozqp6jicCkStZNi3jAsHF8CkIEmBs
+        3TP3mgM6tssspzViheN2PKyyAWxNyhlbxQWV4HhnMQMTFsUzE4gbsIV3pAafQfQZ
+        XCmFqZ2rU+oVJWtYP7YLenBojgp1Q41WMxFODzdVrnQh4uVisL3WHkEMvond4kJA
+        rDjUbuU4YDTXZSk097IUeTaZ59USEyDT9nyrT+resrGq8pjcrF8XnEHQWlaLVeis
+        WX7QlyD8AxQ1nxr1LnXPslyuivo66zkc9zip/QIDAQABAoIBAQDMUZCxRCW9tZg1
+        YAjJrpEajRA/3ZGzeMzvrKmHB8j0+RmCfioY0aAhigu15rbtDU+1Dsyigp3F2qtF
+        JHW0c56NvHeg9LUrS85kkuP5lyQrH0qgrXC4lZfKZJjz+EqnJTsDtrC0LV05veZF
+        IIFwn3Jgq7SysF0/dBSHOSZF24lVpgcSP0A4aN7E4pFr0CdezyxtndzEoIpnr0o/
+        PoklYRa/iO+eRwy3AI0zo6eld/a4KUEy5ZlsOWcoTHWXuz1C/kdfGFRHAiqiM7wp
+        yjIw6OE6KnycLsUdJa+eGmsPSEmh/LrLVrr01GvZe4Dvep7AUmJYRqK3h4+orCsC
+        J0FshqmNAoGBAOHW0no56oPeHGKwPr5k6DvzpsQr5kqmS1J4679LKWdMBlf1SWza
+        b9GObItTBJ+FS0pWLJX7aSi+Kj4ZdvQxiKYeS//zqh/vh9oCKzkUx3c+8kRDv+iw
+        FTYmRqkmwvE7xJrYZG5f+V6pGiygwd2VrB/WmeRMMdfsmqGRno7BjR3nAoGBAO7w
+        4PKfbk0ilPoHxyonNEKnlff53rA46QTfD0gzvFh7507AeGlypnssn2L6FM7Pt6Mt
+        uaFh3bF2Xus4Rmmtxozu+eEu7I4R01pjCgVGXuLeEgp7eMmt4UIXXIc6XgtUl/T6
+        ti7+RmkVo6Hg3uPc48pue6lAYbyva6+eNTWCGNR7AoGAY79QQ2/lJs0pWGVjsRA8
+        io45MBf7pSkBx7Fk3p7B8L/hZWQPRCbOkI4JXxgRyKtE79ZT5wKeFcK4QalZos1l
+        /4kOJERo9aYEKMQgdxu4ZfDFbGVIE+wB0mLhfsCCBa5STdoZsa5uI+MojmGKfuYm
+        mgFdAzqsISR9v7Ljh0XxoC0CgYAS+DazrGqiXxN6wjFSrGgevpVOaZz/WpVNWLQq
+        5EiYscWMYAVvQbXr44AH6JjMTntizheFs3JZS29/tykH7M7tk29tLD+Fi+6+p0w9
+        XPfdhQnjoSfWwyI2EAq9ham/toiV322lT3ShlSE3kdXAO2IuSRUyO7VGuJqRB7tr
+        sxdrjwKBgQCNSPfcT6DBGynbLoh3HfhvLlRbbnR5PfftuERL1k+VftZYLhlnRBCP
+        UH0KTYcPtm72dBZvtEgZLRkBtXft4QlYVo3USeKV2FOYUUY1BJvUa3iqeWa0NUuM
+        nUknj1DCiM4ezkFsbs5lceHxndFBoUqAvnqFs5v1GWWKIcTF5XnOLQ==
+        -----END RSA PRIVATE KEY-----
+version_info: "0"

--- a/jobs/envoy/templates/sds-server-cert-and-key.yaml.erb
+++ b/jobs/envoy/templates/sds-server-cert-and-key.yaml.erb
@@ -4,76 +4,8 @@ resources:
   tls_certificate:
     certificate_chain:
       inline_string: |
-        -----BEGIN CERTIFICATE-----
-        MIID8zCCAtugAwIBAgIRAMw1kJA6YUArVF0UsjUgobEwDQYJKoZIhvcNAQELBQAw
-        HTEbMBkGA1UEAxMSaW5zdGFuY2VJZGVudGl0eUNBMB4XDTIxMDMwMjE5MjUxM1oX
-        DTIxMDMwMzE5MjUxM1owgcgxgZ4wLwYDVQQLEyhhcHA6ZGRlN2YxZmItNDg1ZC00
-        NjNmLTg3ZDUtNWQ5MGIxZTNmMDUwMDEGA1UECxMqc3BhY2U6ZmY4NzAzNGQtZGRk
-        Yi00YjlmLThmNWYtODhiZmQxZTM1ZGRkMDgGA1UECxMxb3JnYW5pemF0aW9uOmMy
-        YWM3ZWQxLTQzZTItNGI2MC1iOWYxLTUyYWNlMWU4NGU1ZDElMCMGA1UEAxMcZWY1
-        NGExNDgtNGY0OC00NWI5LTdmZDEtODQzNjCCASIwDQYJKoZIhvcNAQEBBQADggEP
-        ADCCAQoCggEBANLKN4T2UffAi3Jj1F79jIgO+GY40eoDzD3jxXPFwnuCRt5L6vWz
-        1JpB8UIlBacsdw2WPOGPH5WUdl2hPG6iaM6qeo4nApErWTYt4wLBxfApCBJgbN0z
-        95oDOrbLLKc1YoXjdjyssgFsTcoZW8UFleB4ZzEDExbFMxOIG7CFd6QGn0H0GVwp
-        hamdq1PqFSVrWD+2C3pwaI4KdUONVjMRTg83Va50IeLlYrC91h5BDL6J3eJCQKw4
-        1G7lOGA012UpNPeyFHk2mefVEhMg0/Z8q0/q3rKxqvKY3KxfF5xB0FpWi1XorFl+
-        0Jcg/AMUNZ8a9S51z7Jcror6Ous5HPc4qf0CAwEAAaOBgTB/MA4GA1UdDwEB/wQE
-        AwIDqDAdBgNVHSUEFjAUBggrBgEFBQcDAgYIKwYBBQUHAwEwHwYDVR0jBBgwFoAU
-        obDjWbp4kN6+EiGqO5L5wX1NXN0wLQYDVR0RBCYwJIIcZWY1NGExNDgtNGY0OC00
-        NWI5LTdmZDEtODQzNocECv/yODANBgkqhkiG9w0BAQsFAAOCAQEAo+QbfyWu+Cuj
-        HzyqT5SgFcfp7YmRkI80vFR+KKNzU6HmbEIfcllfnOU5nyLCz99hMWP+NqyOy7NB
-        o840RdyyvoctFWgNMo5YtM34hNmnxA2Y5Hmgty6nmcOVKVmcKVjVXRVQxPgUKIBp
-        6lbzBh6fFe+NzbzYbfRLJdoOs6EAlTrUgFxSolOCArl1Lxq9UoV0mm9q9MdeQUut
-        zrlcvxfV37ygmSxU8bsIlbFRz5rQ6bkm9mECtvO4BfJ9h3hD9Hqv1/788Bc6Knag
-        vmcZKrff2bbv47tJngGgb9iNY3MAQUSZVfo6t013RLBSQJEF65UMk3TAZEoFTy4q
-        2w9l90cbRQ==
-        -----END CERTIFICATE-----
-        -----BEGIN CERTIFICATE-----
-        MIIDEjCCAfqgAwIBAgIUEUIA+osyBcSIDvc0w5TMCRfzNokwDQYJKoZIhvcNAQEL
-        BQAwFDESMBAGA1UEAxMJYXBwUm9vdENBMB4XDTIxMDMwMjExNDMyOFoXDTIyMDMw
-        MjExNDMyOFowHTEbMBkGA1UEAxMSaW5zdGFuY2VJZGVudGl0eUNBMIIBIjANBgkq
-        hkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuGnM+CcZEyH8r/K0pFKt2CRVY20x9php
-        Xg50dvBUCLp3tCXrGR13gfkL5krHFK2IJqe1E3Q9n0xo+yiHny35UkE911/plC9h
-        0GfuWAgEic4SdvB6cA/Lbx1ekRBR8ZkSZfu0Fl1AE9oHdJmfzZrkqEpSizcE3DZE
-        TmsjO/NuMVjwrFVddkMMDr0bsD8xVm2C0bEVMSuLvgG0NMkQn9NsBBxc5HvKQo2S
-        gVQFLLgEvc5eYxmeRG8/Ncsy/3fzdhs+lUquFaAIxwITBTbyg2HtYgtdMzy08BWf
-        3i8IpyZ/e5DFOWJkcXj+bG/WU2TVipzOoEMBY8R9IvUjuLwFMZb1fwIDAQABo1Mw
-        UTAdBgNVHQ4EFgQUobDjWbp4kN6+EiGqO5L5wX1NXN0wHwYDVR0jBBgwFoAUpR+U
-        KIaorXZavygFU3LNEchuY8owDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsF
-        AAOCAQEAgqmuKS9HNS9p/b/k+8akVFWl2+cC6o/Yat0+uVncgrPgp2T6D1iAIQlH
-        xQSfDbCR8ksLGP/HhHsX/amfqxiBFlbzZbdH9FPZuIsMcW5K/t0LxR9fiwsP7HDK
-        pI6wHne/60hLKDYrWE8GppckhujfxcVdDY63qYcErONkWcaa11tMKVFrD0UKuLkb
-        ATOiE3IBZ3VbgvVUopTTbLlkaSzJOi/OzJB0JKWnCmrEuQxUgQ2jI28brYezGz7h
-        MhWJbFQCweE5v9zWHbHgHixOu5P0IK3d0BEZcbg8BnOIqoVN21n0hst5jeNv0z9K
-        dFmH+iNb0bUWmLXYK2jeZG5+yTvzYQ==
-        -----END CERTIFICATE-----
+        <%= p("server_tls.certificate").gsub("\n","\n        ") %>
     private_key:
       inline_string: |
-        -----BEGIN RSA PRIVATE KEY-----
-        MIIEpAIBAAKCAQEA0so3hPZR98CLcmPUXv2MiA74ZjjR6gPMPePFc8XCe4JG3kvq
-        9bPUmkHxQiUFpyx3DZY84Y8flZR2XaE8bqJozqp6jicCkStZNi3jAsHF8CkIEmBs
-        3TP3mgM6tssspzViheN2PKyyAWxNyhlbxQWV4HhnMQMTFsUzE4gbsIV3pAafQfQZ
-        XCmFqZ2rU+oVJWtYP7YLenBojgp1Q41WMxFODzdVrnQh4uVisL3WHkEMvond4kJA
-        rDjUbuU4YDTXZSk097IUeTaZ59USEyDT9nyrT+resrGq8pjcrF8XnEHQWlaLVeis
-        WX7QlyD8AxQ1nxr1LnXPslyuivo66zkc9zip/QIDAQABAoIBAQDMUZCxRCW9tZg1
-        YAjJrpEajRA/3ZGzeMzvrKmHB8j0+RmCfioY0aAhigu15rbtDU+1Dsyigp3F2qtF
-        JHW0c56NvHeg9LUrS85kkuP5lyQrH0qgrXC4lZfKZJjz+EqnJTsDtrC0LV05veZF
-        IIFwn3Jgq7SysF0/dBSHOSZF24lVpgcSP0A4aN7E4pFr0CdezyxtndzEoIpnr0o/
-        PoklYRa/iO+eRwy3AI0zo6eld/a4KUEy5ZlsOWcoTHWXuz1C/kdfGFRHAiqiM7wp
-        yjIw6OE6KnycLsUdJa+eGmsPSEmh/LrLVrr01GvZe4Dvep7AUmJYRqK3h4+orCsC
-        J0FshqmNAoGBAOHW0no56oPeHGKwPr5k6DvzpsQr5kqmS1J4679LKWdMBlf1SWza
-        b9GObItTBJ+FS0pWLJX7aSi+Kj4ZdvQxiKYeS//zqh/vh9oCKzkUx3c+8kRDv+iw
-        FTYmRqkmwvE7xJrYZG5f+V6pGiygwd2VrB/WmeRMMdfsmqGRno7BjR3nAoGBAO7w
-        4PKfbk0ilPoHxyonNEKnlff53rA46QTfD0gzvFh7507AeGlypnssn2L6FM7Pt6Mt
-        uaFh3bF2Xus4Rmmtxozu+eEu7I4R01pjCgVGXuLeEgp7eMmt4UIXXIc6XgtUl/T6
-        ti7+RmkVo6Hg3uPc48pue6lAYbyva6+eNTWCGNR7AoGAY79QQ2/lJs0pWGVjsRA8
-        io45MBf7pSkBx7Fk3p7B8L/hZWQPRCbOkI4JXxgRyKtE79ZT5wKeFcK4QalZos1l
-        /4kOJERo9aYEKMQgdxu4ZfDFbGVIE+wB0mLhfsCCBa5STdoZsa5uI+MojmGKfuYm
-        mgFdAzqsISR9v7Ljh0XxoC0CgYAS+DazrGqiXxN6wjFSrGgevpVOaZz/WpVNWLQq
-        5EiYscWMYAVvQbXr44AH6JjMTntizheFs3JZS29/tykH7M7tk29tLD+Fi+6+p0w9
-        XPfdhQnjoSfWwyI2EAq9ham/toiV322lT3ShlSE3kdXAO2IuSRUyO7VGuJqRB7tr
-        sxdrjwKBgQCNSPfcT6DBGynbLoh3HfhvLlRbbnR5PfftuERL1k+VftZYLhlnRBCP
-        UH0KTYcPtm72dBZvtEgZLRkBtXft4QlYVo3USeKV2FOYUUY1BJvUa3iqeWa0NUuM
-        nUknj1DCiM4ezkFsbs5lceHxndFBoUqAvnqFs5v1GWWKIcTF5XnOLQ==
-        -----END RSA PRIVATE KEY-----
+        <%= p("server_tls.private_key").gsub("\n","\n        ") %>
 version_info: "0"

--- a/jobs/envoy/templates/sds-server-validation-context.yaml.erb
+++ b/jobs/envoy/templates/sds-server-validation-context.yaml.erb
@@ -1,0 +1,45 @@
+resources:
+- '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
+  name: server-validation-context
+  validation_context:
+    trusted_ca:
+      inline_string: |
+        -----BEGIN CERTIFICATE-----
+        MIIDCzCCAfOgAwIBAgIUcoY/Ok2zrj59ikfYFwISK4JNj/QwDQYJKoZIhvcNAQEL
+        BQAwFTETMBEGA1UEAxMKaW50ZXJuYWxDQTAeFw0yMTAzMDIxMTQzMDZaFw0yMjAz
+        MDIxMTQzMDZaMBUxEzARBgNVBAMTCmludGVybmFsQ0EwggEiMA0GCSqGSIb3DQEB
+        AQUAA4IBDwAwggEKAoIBAQDYWgRtwVtOQKBExDOokXtZu5dMcnxusPBFwz/ZDMJZ
+        5lm9CF/e0Jf/G2XUg06o0iWJS1MdhGo/0YQVBChECQ/aCSRbLs1PAORZAtPZWbMq
+        iOuDma1ennhZFbtW+FQVMzKLK8XyrWuZNmrLLg9ShddR8fEpEwdlRxM5hmD64Tkv
+        ZR3F2BP+BsyyCFCRHhmEcx6YQ+Lxiov/CtnmHlyECCeQeLaLpktEYyu85l1q81hn
+        NMPIRHCQk5JDXtAsEGUlcXEOoBUuCj2SvGY/XEy5n1CQXuSUZmfc4RG45wWbZMo7
+        EddH9nkeWaGhSi7e2XDRqFP7jQhf8Epyp/4/jLaKDRTtAgMBAAGjUzBRMB0GA1Ud
+        DgQWBBTPVOsiGKQ2RZhV1fPBzGrHFcXyijAfBgNVHSMEGDAWgBTPVOsiGKQ2RZhV
+        1fPBzGrHFcXyijAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQC9
+        LO2qApu+kI5nfV6vRZ8RBz3f0RF8QsobdlUSiH6snQxqFug6J2N7QFofATSSYorN
+        HlmGhtg7wyDaPsvGzgMR0PU2O6qSN1d5O63hAoqCzmoXDGf5kfUxGPjr56I2JnfR
+        Fw/UYB7hwuzcrVgNIYS6vAeHxjCbdTBQ1jT8qdxDswBl9ek/lj2lW5AaDGOWhUD+
+        3nzRn0D7Q5RIVuPPpIYhCezGVuLF3uL6/3ra0Z0d74zNI9xv4ukNBF0KXZzwI3Ze
+        ejFDI5En9UX/mhXL/94rgzr8q3v1pdW1ENsjFC557QryiBHqDOcNUoylnGGmbtJa
+        6gRCZ3hWYHw0n2GCkrVo
+        -----END CERTIFICATE-----
+        -----BEGIN CERTIFICATE-----
+        MIIDCzCCAfOgAwIBAgIUcoY/Ok2zrj59ikfYFwISK4JNj/QwDQYJKoZIhvcNAQEL
+        BQAwFTETMBEGA1UEAxMKaW50ZXJuYWxDQTAeFw0yMTAzMDIxMTQzMDZaFw0yMjAz
+        MDIxMTQzMDZaMBUxEzARBgNVBAMTCmludGVybmFsQ0EwggEiMA0GCSqGSIb3DQEB
+        AQUAA4IBDwAwggEKAoIBAQDYWgRtwVtOQKBExDOokXtZu5dMcnxusPBFwz/ZDMJZ
+        5lm9CF/e0Jf/G2XUg06o0iWJS1MdhGo/0YQVBChECQ/aCSRbLs1PAORZAtPZWbMq
+        iOuDma1ennhZFbtW+FQVMzKLK8XyrWuZNmrLLg9ShddR8fEpEwdlRxM5hmD64Tkv
+        ZR3F2BP+BsyyCFCRHhmEcx6YQ+Lxiov/CtnmHlyECCeQeLaLpktEYyu85l1q81hn
+        NMPIRHCQk5JDXtAsEGUlcXEOoBUuCj2SvGY/XEy5n1CQXuSUZmfc4RG45wWbZMo7
+        EddH9nkeWaGhSi7e2XDRqFP7jQhf8Epyp/4/jLaKDRTtAgMBAAGjUzBRMB0GA1Ud
+        DgQWBBTPVOsiGKQ2RZhV1fPBzGrHFcXyijAfBgNVHSMEGDAWgBTPVOsiGKQ2RZhV
+        1fPBzGrHFcXyijAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQC9
+        LO2qApu+kI5nfV6vRZ8RBz3f0RF8QsobdlUSiH6snQxqFug6J2N7QFofATSSYorN
+        HlmGhtg7wyDaPsvGzgMR0PU2O6qSN1d5O63hAoqCzmoXDGf5kfUxGPjr56I2JnfR
+        Fw/UYB7hwuzcrVgNIYS6vAeHxjCbdTBQ1jT8qdxDswBl9ek/lj2lW5AaDGOWhUD+
+        3nzRn0D7Q5RIVuPPpIYhCezGVuLF3uL6/3ra0Z0d74zNI9xv4ukNBF0KXZzwI3Ze
+        ejFDI5En9UX/mhXL/94rgzr8q3v1pdW1ENsjFC557QryiBHqDOcNUoylnGGmbtJa
+        6gRCZ3hWYHw0n2GCkrVo
+        -----END CERTIFICATE-----
+version_info: "0"

--- a/jobs/envoy/templates/sds-server-validation-context.yaml.erb
+++ b/jobs/envoy/templates/sds-server-validation-context.yaml.erb
@@ -4,42 +4,5 @@ resources:
   validation_context:
     trusted_ca:
       inline_string: |
-        -----BEGIN CERTIFICATE-----
-        MIIDCzCCAfOgAwIBAgIUcoY/Ok2zrj59ikfYFwISK4JNj/QwDQYJKoZIhvcNAQEL
-        BQAwFTETMBEGA1UEAxMKaW50ZXJuYWxDQTAeFw0yMTAzMDIxMTQzMDZaFw0yMjAz
-        MDIxMTQzMDZaMBUxEzARBgNVBAMTCmludGVybmFsQ0EwggEiMA0GCSqGSIb3DQEB
-        AQUAA4IBDwAwggEKAoIBAQDYWgRtwVtOQKBExDOokXtZu5dMcnxusPBFwz/ZDMJZ
-        5lm9CF/e0Jf/G2XUg06o0iWJS1MdhGo/0YQVBChECQ/aCSRbLs1PAORZAtPZWbMq
-        iOuDma1ennhZFbtW+FQVMzKLK8XyrWuZNmrLLg9ShddR8fEpEwdlRxM5hmD64Tkv
-        ZR3F2BP+BsyyCFCRHhmEcx6YQ+Lxiov/CtnmHlyECCeQeLaLpktEYyu85l1q81hn
-        NMPIRHCQk5JDXtAsEGUlcXEOoBUuCj2SvGY/XEy5n1CQXuSUZmfc4RG45wWbZMo7
-        EddH9nkeWaGhSi7e2XDRqFP7jQhf8Epyp/4/jLaKDRTtAgMBAAGjUzBRMB0GA1Ud
-        DgQWBBTPVOsiGKQ2RZhV1fPBzGrHFcXyijAfBgNVHSMEGDAWgBTPVOsiGKQ2RZhV
-        1fPBzGrHFcXyijAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQC9
-        LO2qApu+kI5nfV6vRZ8RBz3f0RF8QsobdlUSiH6snQxqFug6J2N7QFofATSSYorN
-        HlmGhtg7wyDaPsvGzgMR0PU2O6qSN1d5O63hAoqCzmoXDGf5kfUxGPjr56I2JnfR
-        Fw/UYB7hwuzcrVgNIYS6vAeHxjCbdTBQ1jT8qdxDswBl9ek/lj2lW5AaDGOWhUD+
-        3nzRn0D7Q5RIVuPPpIYhCezGVuLF3uL6/3ra0Z0d74zNI9xv4ukNBF0KXZzwI3Ze
-        ejFDI5En9UX/mhXL/94rgzr8q3v1pdW1ENsjFC557QryiBHqDOcNUoylnGGmbtJa
-        6gRCZ3hWYHw0n2GCkrVo
-        -----END CERTIFICATE-----
-        -----BEGIN CERTIFICATE-----
-        MIIDCzCCAfOgAwIBAgIUcoY/Ok2zrj59ikfYFwISK4JNj/QwDQYJKoZIhvcNAQEL
-        BQAwFTETMBEGA1UEAxMKaW50ZXJuYWxDQTAeFw0yMTAzMDIxMTQzMDZaFw0yMjAz
-        MDIxMTQzMDZaMBUxEzARBgNVBAMTCmludGVybmFsQ0EwggEiMA0GCSqGSIb3DQEB
-        AQUAA4IBDwAwggEKAoIBAQDYWgRtwVtOQKBExDOokXtZu5dMcnxusPBFwz/ZDMJZ
-        5lm9CF/e0Jf/G2XUg06o0iWJS1MdhGo/0YQVBChECQ/aCSRbLs1PAORZAtPZWbMq
-        iOuDma1ennhZFbtW+FQVMzKLK8XyrWuZNmrLLg9ShddR8fEpEwdlRxM5hmD64Tkv
-        ZR3F2BP+BsyyCFCRHhmEcx6YQ+Lxiov/CtnmHlyECCeQeLaLpktEYyu85l1q81hn
-        NMPIRHCQk5JDXtAsEGUlcXEOoBUuCj2SvGY/XEy5n1CQXuSUZmfc4RG45wWbZMo7
-        EddH9nkeWaGhSi7e2XDRqFP7jQhf8Epyp/4/jLaKDRTtAgMBAAGjUzBRMB0GA1Ud
-        DgQWBBTPVOsiGKQ2RZhV1fPBzGrHFcXyijAfBgNVHSMEGDAWgBTPVOsiGKQ2RZhV
-        1fPBzGrHFcXyijAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQC9
-        LO2qApu+kI5nfV6vRZ8RBz3f0RF8QsobdlUSiH6snQxqFug6J2N7QFofATSSYorN
-        HlmGhtg7wyDaPsvGzgMR0PU2O6qSN1d5O63hAoqCzmoXDGf5kfUxGPjr56I2JnfR
-        Fw/UYB7hwuzcrVgNIYS6vAeHxjCbdTBQ1jT8qdxDswBl9ek/lj2lW5AaDGOWhUD+
-        3nzRn0D7Q5RIVuPPpIYhCezGVuLF3uL6/3ra0Z0d74zNI9xv4ukNBF0KXZzwI3Ze
-        ejFDI5En9UX/mhXL/94rgzr8q3v1pdW1ENsjFC557QryiBHqDOcNUoylnGGmbtJa
-        6gRCZ3hWYHw0n2GCkrVo
-        -----END CERTIFICATE-----
-version_info: "0"
+        <%= p("client_validation.ca_certificate").gsub("\n", "\n        ") %>
+      version_info: "0"

--- a/jobs/performance_tests/spec
+++ b/jobs/performance_tests/spec
@@ -4,6 +4,8 @@ name: performance_tests
 templates:
   run.erb: bin/run
   run_perf_test.erb: bin/run_perf_test
+  client.crt.erb: config/certs/client.crt
+  client.key.erb: config/certs/client.key
 
 packages:
   - hey
@@ -21,6 +23,10 @@ consumes:
   type: backend
 
 properties:
+  client_certificate:
+    description: Certificate to use for mutual TLS with envoy
+  client_private_key:
+    description: Private key to use for mutual TLS with envoy
   performance_tests.tag:
     description: The tag to be used when data is sent to datadog.
   performance_tests.host:

--- a/jobs/performance_tests/templates/client.crt.erb
+++ b/jobs/performance_tests/templates/client.crt.erb
@@ -1,0 +1,1 @@
+<%= p('client_certificate') %>

--- a/jobs/performance_tests/templates/client.key.erb
+++ b/jobs/performance_tests/templates/client.key.erb
@@ -1,0 +1,1 @@
+<%= p("client_private_key") %>

--- a/jobs/performance_tests/templates/run_perf_test.erb
+++ b/jobs/performance_tests/templates/run_perf_test.erb
@@ -3,8 +3,9 @@
 set -e
 
 LOG_DIR=/var/vcap/sys/log/performance_tests
-GOSTATIC_BACKEND_URI=http://<%= link("static").instances[0].address %>:8080
+GOSTATIC_BACKEND_HOST=<%= link("static").instances[0].address %>
 GOROUTER_PROXY_URI=<%= p("performance_tests.protocol") %>://${1}:<%= p("performance_tests.port") %>
+GOROUTER_HTTPS_PROXY_URI=https://${1}
 
 RPS_LOWER_LIMIT=<%= p("performance_tests.throughput_lower_limit") %>
 LATENCY_UPPER_LIMIT_90=<%= p("performance_tests.latency_upper_limit_90") %>
@@ -28,8 +29,8 @@ ensure_log_dir() {
 run_perf_tests() {
   date=$(date +%s)
 
-  # run load test
-  echo "Starting routed load test of ${TOTAL_REQUESTS} requests, ${TOTAL_CONCURRENT} concurrent..."
+  # run load test against gorouter using http1
+  echo "Starting gorouter http1 load test of ${TOTAL_REQUESTS} requests, ${TOTAL_CONCURRENT} concurrent..."
   exec /var/vcap/packages/hey/bin/hey \
     -n $TOTAL_REQUESTS \
     -c $TOTAL_CONCURRENT \
@@ -38,12 +39,34 @@ run_perf_tests() {
     ${GOROUTER_PROXY_URI} | tee ${LOG_DIR}/routed_loadtest_${date}.log
   echo ""
 
-  echo "Starting direct load test of ${TOTAL_REQUESTS} requests, ${TOTAL_CONCURRENT} concurrent..."
+  # run load test against gorouter using http2
+  echo "Starting gorouter http2 load test of ${TOTAL_REQUESTS} requests, ${TOTAL_CONCURRENT} concurrent..."
   exec /var/vcap/packages/hey/bin/hey \
     -n $TOTAL_REQUESTS \
     -c $TOTAL_CONCURRENT \
     -t 0 \
-    ${GOSTATIC_BACKEND_URI} | tee ${LOG_DIR}/direct_loadtest_${date}.log
+    -h2 \
+    -host "<%=p("performance_tests.host") %>" \
+    ${GOROUTER_HTTPS_PROXY_URI} | tee ${LOG_DIR}/routed_loadtest_${date}.log
+  echo ""
+
+  # run load test aginst gostatic envoy
+  echo "Starting gostatic envoy test of ${TOTAL_REQUESTS} requests, ${TOTAL_CONCURRENT} concurrent..."
+  exec /var/vcap/packages/hey/bin/hey \
+    -n $TOTAL_REQUESTS \
+    -c $TOTAL_CONCURRENT \
+    -t 0 \
+    -cert /var/vcap/jobs/performance_tests/config/certs/client.crt \
+    -key /var/vcap/jobs/performance_tests/config/certs/client.key \
+    https://${GOSTATIC_BACKEND_HOST}:61001 | tee ${LOG_DIR}/routed_loadtest_${date}.log
+    echo ""
+
+  echo "Starting gostatic direct load test of ${TOTAL_REQUESTS} requests, ${TOTAL_CONCURRENT} concurrent..."
+  exec /var/vcap/packages/hey/bin/hey \
+    -n $TOTAL_REQUESTS \
+    -c $TOTAL_CONCURRENT \
+    -t 0 \
+    http://${GOSTATIC_BACKEND_HOST}:8080 | tee ${LOG_DIR}/direct_loadtest_${date}.log
   echo ""
 
   # requests / sec

--- a/jobs/performance_tests/templates/run_perf_test.erb
+++ b/jobs/performance_tests/templates/run_perf_test.erb
@@ -3,6 +3,17 @@
 set -e
 
 LOG_DIR=/var/vcap/sys/log/performance_tests
+GOSTATIC_BACKEND_URI=http://<%= link("static").instances[0].address %>:8080
+GOROUTER_PROXY_URI=<%= p("performance_tests.protocol") %>://${1}:<%= p("performance_tests.port") %>
+
+RPS_LOWER_LIMIT=<%= p("performance_tests.throughput_lower_limit") %>
+LATENCY_UPPER_LIMIT_90=<%= p("performance_tests.latency_upper_limit_90") %>
+LATENCY_UPPER_LIMIT_95=<%= p("performance_tests.latency_upper_limit_95") %>
+LATENCY_UPPER_LIMIT_99=<%= p("performance_tests.latency_upper_limit_99") %>
+
+TOTAL_REQUESTS=<%= p("performance_tests.num_requests") %>
+TOTAL_CONCURRENT=<%= p("performance_tests.concurrent_requests") %>
+
 
 RPS=0
 LATENCY_90=0
@@ -10,23 +21,12 @@ LATENCY_95=0
 LATENCY_99=0
 NUM_OK="could not extract status codes of responses from summary"
 
-BACKEND_ADDRESS=<%= link("static").instances[0].address %>
-RPS_LOWER_LIMIT=<%= p("performance_tests.throughput_lower_limit") %>
-LATENCY_UPPER_LIMIT_90=<%= p("performance_tests.latency_upper_limit_90") %>
-LATENCY_UPPER_LIMIT_95=<%= p("performance_tests.latency_upper_limit_95") %>
-LATENCY_UPPER_LIMIT_99=<%= p("performance_tests.latency_upper_limit_99") %>
-TOTAL_REQUESTS=<%= p("performance_tests.num_requests") %>
-TOTAL_CONCURRENT=<%= p("performance_tests.concurrent_requests") %>
-URI=<%= p("performance_tests.protocol") %>://${1}:<%= p("performance_tests.port") %>
-ROUTER=${2}
-
 ensure_log_dir() {
   mkdir -p ${LOG_DIR}
 }
 
 run_perf_tests() {
   date=$(date +%s)
-  num_loops=$((<%= p("performance_tests.num_requests") %>/<%=p("performance_tests.concurrent_requests")%>))
 
   # run load test
   echo "Starting routed load test of ${TOTAL_REQUESTS} requests, ${TOTAL_CONCURRENT} concurrent..."
@@ -35,7 +35,7 @@ run_perf_tests() {
     -c $TOTAL_CONCURRENT \
     -t 0 \
     -host "<%=p("performance_tests.host") %>" \
-    ${URI} | tee ${LOG_DIR}/routed_loadtest_${date}.log
+    ${GOROUTER_PROXY_URI} | tee ${LOG_DIR}/routed_loadtest_${date}.log
   echo ""
 
   echo "Starting direct load test of ${TOTAL_REQUESTS} requests, ${TOTAL_CONCURRENT} concurrent..."
@@ -43,7 +43,7 @@ run_perf_tests() {
     -n $TOTAL_REQUESTS \
     -c $TOTAL_CONCURRENT \
     -t 0 \
-    http://${BACKEND_ADDRESS}:8080 | tee ${LOG_DIR}/direct_loadtest_${date}.log
+    ${GOSTATIC_BACKEND_URI} | tee ${LOG_DIR}/direct_loadtest_${date}.log
   echo ""
 
   # requests / sec
@@ -67,29 +67,9 @@ run_perf_tests() {
   NUM_OK=$(grep -E "\[200\].*responses" ${LOG_DIR}/routed_loadtest_${date}.log | awk '{ print $2 }')
 }
 
-emit_datadog_metrics() {
-  rps=$1
-  latency90=$2
-  latency95=$3
-  latency99=$4
-  currenttime=$(date +%s)
-  deployment=<%= spec.deployment %>
-  version=<%= p("performance_tests.routing_release_version") %>
-
-  curl -X POST -H "Content-type: application/json" -d "
-    {\"series\": [
-    {\"metric\":\"performance.requests_per_second\", \"points\":[[$currenttime, $rps]],       \"tags\":[\"deployment:$deployment\", \"router:${ROUTER}\", \"version:$version\"], \"type\":\"gauge\" },
-    {\"metric\":\"performance.latency_90\",          \"points\":[[$currenttime, $latency90]], \"tags\":[\"deployment:$deployment\", \"router:${ROUTER}\", \"version:$version\"], \"type\":\"gauge\" },
-    {\"metric\":\"performance.latency_95\",          \"points\":[[$currenttime, $latency95]], \"tags\":[\"deployment:$deployment\", \"router:${ROUTER}\", \"version:$version\"], \"type\":\"gauge\" },
-    {\"metric\":\"performance.latency_99\",          \"points\":[[$currenttime, $latency99]], \"tags\":[\"deployment:$deployment\", \"router:${ROUTER}\", \"version:$version\"], \"type\":\"gauge\" }
-    ]}" \
-    'https://app.datadoghq.com/api/v1/series?api_key=<%=p("performance_tests.datadog_api_key") %>'
-
-  echo
-}
 
 main() {
-  echo "Performance test run for ${ROUTER} at ${URI}:"
+  echo "Performance test run for ${GOROUTER_PROXY_URI}:"
   ensure_log_dir
   run_perf_tests
 

--- a/manifests/bran.yml
+++ b/manifests/bran.yml
@@ -73,6 +73,7 @@ instance_groups:
         - cert_chain: "((application_ca.certificate))"
           private_key: "((application_ca.private_key))"
         enable_ssl: true
+        enable_http2: true
         ca_certs: |
           ((application_ca.certificate))
         debug_address: 0.0.0.0:17002
@@ -127,7 +128,7 @@ instance_groups:
       http_route_populator:
         app_domain: foo.com
         app_name: gostatic
-        num_routes: 100000
+        num_routes: 50_000
   networks:
   - name: default
 

--- a/manifests/bran.yml
+++ b/manifests/bran.yml
@@ -142,7 +142,7 @@ instance_groups:
         latency_upper_limit_90: 1.85
         latency_upper_limit_95: 1.95
         latency_upper_limit_99: 3.15
-#  lifecycle: errand
+  lifecycle: errand
   networks:
   - name: default
 

--- a/manifests/bran.yml
+++ b/manifests/bran.yml
@@ -1,0 +1,160 @@
+---
+name: perf-test
+
+update:
+  canaries: 1
+  canary_watch_time: 1000-180000
+  max_in_flight: 50
+  serial: false
+  update_watch_time: 1000-180000
+addons:
+- name: bpm
+  include:
+    stemcell:
+    - os: ubuntu-xenial
+  jobs:
+  - name: bpm
+    release: bpm
+
+releases:
+- name: nats
+  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=22
+  version: "22"
+  sha1: 1300071c7cf43f5d299a6eaec6f6bb6cca7eac3b
+- name: routing
+  version: latest
+- name: routing-perf
+  version: latest
+- name: bpm
+  url: https://bosh.io/d/github.com/cloudfoundry-incubator/bpm-release?v=0.9.0
+  version: 0.9.0
+  sha1: 0cb3242063c95271c95b62de3a6d07072aff0b29
+
+stemcells:
+- alias: xenial
+  os: ubuntu-xenial
+  version: latest
+
+instance_groups:
+- name: nats
+  instances: 1
+  vm_type: default
+  stemcell: xenial
+  azs: [z1]
+  networks:
+  - name: default
+  jobs:
+  - name: nats
+    release: nats
+    provides:
+      nats: {as: nats, shared: true}
+    properties:
+      nats:
+        debug: false
+        monitor_port: 4221
+        prof_port: 0
+        trace: false
+        user: nats
+        password: ((nats_password))
+
+- name: router
+  instances: 1
+  vm_type: c3.large
+  stemcell: xenial
+  azs: [z1]
+  networks:
+  - name: default
+  jobs:
+  - name: gorouter
+    release: routing
+    properties:
+      router:
+        ca_certs: |
+          ((application_ca.certificate))
+        debug_address: 0.0.0.0:17002
+        route_services_recommend_https: false
+        route_services_secret: ((router_route_services_secret))
+        ssl_skip_validation: true
+        status:
+          password: ((router_status_password))
+          user: router
+      uaa: # Dummy values to make template evaluation happy
+        clients:
+          gorouter:
+            secret: ""
+        ssl:
+          port: 0
+
+- name: gostatic
+  instances: 1
+  vm_type: c3.large
+  stemcell: xenial
+  azs: [z1]
+  jobs:
+  - name: gostatic
+    release: routing-perf
+    provides:
+      static: {as: gostatic}
+    properties:
+      gostatic:
+        response_size: 1
+  - name: envoy
+    release: routing-perf
+  networks:
+  - name: default
+
+- name: http_route_populator
+  instances: 1
+  vm_type: default
+  stemcell: xenial
+  azs: [z1]
+  jobs:
+  - name: http_route_populator
+    release: routing-perf
+    consumes:
+      static: {from: gostatic}
+    properties:
+      http_route_populator:
+        app_domain: foo.com
+        app_name: gostatic
+        num_routes: 100000
+  networks:
+  - name: default
+
+- name: http_performance_tests
+  instances: 1
+  vm_type: c3.large
+  stemcell: xenial
+  azs:
+  - z1
+  jobs:
+  - name: performance_tests
+    release: routing-perf
+    properties:
+      performance_tests:
+        tag: gorouter
+        host: gostatic-0.foo.com
+        port: 80
+        protocol: http
+        num_requests: 150000
+        concurrent_requests: 2
+        throughput_lower_limit: 1175
+        latency_upper_limit_90: 1.85
+        latency_upper_limit_95: 1.95
+        latency_upper_limit_99: 3.15
+#  lifecycle: errand
+  networks:
+  - name: default
+
+variables:
+- name: router_status_password
+  type: password
+- name: router_route_services_secret
+  type: password
+- name: nats_password
+  type: password
+- name: application_ca
+  type: certificate
+  options:
+    common_name: appRootCA
+    is_ca: true

--- a/manifests/bran.yml
+++ b/manifests/bran.yml
@@ -69,6 +69,10 @@ instance_groups:
     release: routing
     properties:
       router:
+        tls_pem:
+        - cert_chain: "((application_ca.certificate))"
+          private_key: "((application_ca.private_key))"
+        enable_ssl: true
         ca_certs: |
           ((application_ca.certificate))
         debug_address: 0.0.0.0:17002
@@ -100,6 +104,12 @@ instance_groups:
         response_size: 1
   - name: envoy
     release: routing-perf
+    properties:
+      client_validation:
+        ca_certificate: ((application_ca.ca))
+      server_tls:
+        certificate: ((application_ca.certificate))
+        private_key: ((application_ca.private_key))
   networks:
   - name: default
 
@@ -131,6 +141,8 @@ instance_groups:
   - name: performance_tests
     release: routing-perf
     properties:
+      client_certificate: ((application_ca.certificate))
+      client_private_key: ((application_ca.private_key))
       performance_tests:
         tag: gorouter
         host: gostatic-0.foo.com

--- a/packages/envoy/packaging
+++ b/packages/envoy/packaging
@@ -1,7 +1,7 @@
 set -e
 
 # Install envoy binary
-cd proxy
+cd envoy
 tar -xzf envoy-c4b7ab805f238206d8b806e12cedb9420e5d936a-1.16.3.tgz
-mv envoy ${BOSH_INSTALL_TARGET}
-
+mkdir ${BOSH_INSTALL_TARGET}/bin
+mv envoy ${BOSH_INSTALL_TARGET}/bin

--- a/packages/envoy/packaging
+++ b/packages/envoy/packaging
@@ -1,0 +1,7 @@
+set -e
+
+# Install envoy binary
+cd proxy
+tar -xzf envoy-c4b7ab805f238206d8b806e12cedb9420e5d936a-1.16.3.tgz
+mv envoy ${BOSH_INSTALL_TARGET}
+

--- a/packages/envoy/spec
+++ b/packages/envoy/spec
@@ -1,0 +1,8 @@
+---
+name: envoy
+
+dependencies: []
+
+files:
+  - envoy/envoy-c4b7ab805f238206d8b806e12cedb9420e5d936a-1.16.3.tgz
+

--- a/packages/gostatic/spec
+++ b/packages/gostatic/spec
@@ -5,4 +5,5 @@ dependencies:
 files:
   - gostatic/*.go # gosub
   - gostatic/go.mod
+  - gostatic/go.sum
 

--- a/packages/hey/packaging
+++ b/packages/hey/packaging
@@ -9,8 +9,10 @@ mkdir -p ${BOSH_INSTALL_TARGET}/src
 cp -a . ${BOSH_INSTALL_TARGET}/src
 export GOPATH=${BOSH_INSTALL_TARGET}
 
-pushd $GOPATH/src
-  go install github.com/rakyll/hey@v0.1.4
+pushd ${GOPATH}/src/github.com/rakyll/hey/
+  go build
+  mkdir -p ${BOSH_INSTALL_TARGET}/bin
+  cp hey ${BOSH_INSTALL_TARGET}/bin/
 popd
 
 rm -rf ${BOSH_INSTALL_TARGET}/src ${BOSH_INSTALL_TARGET}/pkg

--- a/packages/hey/spec
+++ b/packages/hey/spec
@@ -3,7 +3,7 @@ name: hey
 dependencies:
   - golang-1-linux
 files:
-  - github.com/rakyll/hey/*.go # gosub
+  - github.com/rakyll/hey/* # gergsub
   - github.com/rakyll/hey/requester/*.go # gosub
   - golang.org/x/net/http/httpguts/*.go # gosub
   - golang.org/x/net/http2/*.go # gosub

--- a/src/gostatic/go.mod
+++ b/src/gostatic/go.mod
@@ -1,3 +1,5 @@
 module github.com/cloudfoundry/routing-perf-release/gostatic
 
 go 1.16
+
+require golang.org/x/net v0.0.0-20210415231046-e915ea6b2b7d

--- a/src/gostatic/go.sum
+++ b/src/gostatic/go.sum
@@ -1,0 +1,8 @@
+golang.org/x/net v0.0.0-20210415231046-e915ea6b2b7d h1:BgJvlyh+UqCUaPlscHJ+PN8GcpfrFdr7NHjd1JL0+Gs=
+golang.org/x/net v0.0.0-20210415231046-e915ea6b2b7d/go.mod h1:9tjilg8BloeKEkVJvy7fQ90B1CfIiPueXVOjqfkSzI8=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=
+golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=


### PR DESCRIPTION
We've updated the release to be able to test an http2 gorouter and updated gostatic to have an envoy in the data path so that it mimics the real world.

We're currently running four benchmarks in the errand - against gorouter h1, gorouter h2, envoy and static. We may want to change the assertions at the end to assert that both h1 and h2 tests are fast enough.

todo: 
- [x] Upload the envoy blob somewhere
- [ ] decide how much of this should run in CI
- [ ] consider deleting the jupyter notebook stuff, it's broken maybe